### PR TITLE
git-push

### DIFF
--- a/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
+++ b/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
@@ -43,6 +43,20 @@ class BetterExport extends Command
                 InputOption::VALUE_NONE,
                 'Run \'ticktackk-devtools:git-push\' command'
             )
+            ->addOption(
+                'repo',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Repository to push to',
+                'origin'
+            )
+            ->addOption(
+                'branch',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Branch to push to',
+                null
+            )
         ;
     }
 
@@ -119,7 +133,9 @@ class BetterExport extends Command
             $command = $this->getApplication()->find('ticktackk-devtools:git-push');
             $childInput = new ArrayInput([
                 'command' => 'ticktackk-devtools:git-push',
-                'id' => $addOn->getAddOnId()
+                'id' => $addOn->getAddOnId(),
+                '--repo' => $input->getOption('repo'),
+                '--branch' => $input->getOption('branch')
             ]);
             $command->run($childInput, $output);
         }

--- a/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
+++ b/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
@@ -36,7 +36,14 @@ class BetterExport extends Command
                 'c',
                 InputOption::VALUE_NONE,
                 'Run \'ticktackk-devtools:git-commit\' command'
-            );
+            )
+            ->addOption(
+                'push',
+                'p',
+                InputOption::VALUE_NONE,
+                'Run \'ticktackk-devtools:git-push\' command'
+            )
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -101,6 +108,17 @@ class BetterExport extends Command
             $command = $this->getApplication()->find('ticktackk-devtools:git-commit');
             $childInput = new ArrayInput([
                 'command' => 'ticktackk-devtools:git-commit',
+                'id' => $addOn->getAddOnId()
+            ]);
+            $command->run($childInput, $output);
+        }
+    
+        $push = $input->getOption('push');
+        if ($push)
+        {
+            $command = $this->getApplication()->find('ticktackk-devtools:git-push');
+            $childInput = new ArrayInput([
+                'command' => 'ticktackk-devtools:git-push',
                 'id' => $addOn->getAddOnId()
             ]);
             $command->run($childInput, $output);

--- a/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/Git/Push.php
+++ b/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/Git/Push.php
@@ -5,6 +5,7 @@ namespace TickTackk\DeveloperTools\Cli\Command\Git;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use TickTackk\DeveloperTools\Git\GitRepository;
 use XF\Cli\Command\AddOnActionTrait;
@@ -23,6 +24,20 @@ class Push extends Command
                 'id',
                 InputArgument::REQUIRED,
                 'Add-On ID'
+            )
+            ->addOption(
+                'repo',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Repository to push to',
+                'origin'
+            )
+            ->addOption(
+                'branch',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Branch to push to',
+                null
             );
     }
 
@@ -50,9 +65,22 @@ class Push extends Command
             return 0;
         }
     
-        $git->push()->execute('origin');
+        $repo = $input->getOption('repo');
+        $branch = $input->getOption('branch');
+        
+        // Passing null as second argument doesn't work for some reason
+        if ($branch)
+        {
+            $git->push()->execute($repo, $branch);
+            $output->writeln(["", "Successfully pushed to {$repo}/{$branch}."]);
+            
+        }
+        else
+        {
+            $git->push()->execute($repo);
+            $output->writeln(["", "Successfully pushed to {$repo}."]);
+        }
 
-        $output->writeln(["", "Successfully pushed branch."]);
         return 0;
     }
 }

--- a/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/Git/Push.php
+++ b/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/Git/Push.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace TickTackk\DeveloperTools\Cli\Command\Git;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use TickTackk\DeveloperTools\Git\GitRepository;
+use XF\Cli\Command\AddOnActionTrait;
+use XF\Util\File;
+
+class Push extends Command
+{
+    use AddOnActionTrait;
+
+    protected function configure()
+    {
+        $this
+            ->setName('ticktackk-devtools:git-push')
+            ->setDescription('Push changes to the current tracking branch')
+            ->addArgument(
+                'id',
+                InputArgument::REQUIRED,
+                'Add-On ID'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $id = $input->getArgument('id');
+
+        $addOn = $this->checkEditableAddOn($id, $error);
+        if (!$addOn)
+        {
+            $output->writeln('<error>' . $error . '</error>');
+            return 1;
+        }
+
+        $addOnDirectory = $addOn->getAddOnDirectory();
+        $ds = DIRECTORY_SEPARATOR;
+        $repoRoot = $addOnDirectory . $ds . '_repo';
+
+        File::createDirectory($repoRoot);
+
+        $git = new GitRepository($repoRoot);
+        if (!$git->isInitialized())
+        {
+            $output->writeln(["", "Git directory must be initialized"]);
+            return 0;
+        }
+    
+        $git->push()->execute('origin');
+
+        $output->writeln(["", "Successfully pushed branch."]);
+        return 0;
+    }
+}


### PR DESCRIPTION
This adds support for git-push, which can be chained from better-export. Optional arguments include repository (default: origin) and branch (default: null, which becomes HEAD)