### PR TITLE
Skip entity export when unneeded

### DIFF
--- a/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
+++ b/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
@@ -60,21 +60,14 @@ class BetterExport extends Command
         // xf 2.0.2 bug workaround
         $entityPath = $addOn->getAddOnDirectory() . DIRECTORY_SEPARATOR . 'Entity';
         $entityDirExists = is_dir($entityPath);
-        if (!$entityDirExists)
+        if ($entityDirExists)
         {
-            File::createDirectory($entityPath, false);
-        }
-
-        $command = $this->getApplication()->find('xf-dev:entity-class-properties');
-        $childInput = new ArrayInput([
-            'command' => 'xf-dev:entity-class-properties',
-            'addon-or-entity' => $addOn->getAddOnId()
-        ]);
-        $command->run($childInput, $output);
-
-        if (!$entityDirExists && is_dir($entityPath))
-        {
-            File::deleteDirectory($entityPath);
+            $command = $this->getApplication()->find('xf-dev:entity-class-properties');
+            $childInput = new ArrayInput([
+                'command' => 'xf-dev:entity-class-properties',
+                'addon-or-entity' => $addOn->getAddOnId()
+            ]);
+            $command->run($childInput, $output);
         }
 
         $command = $this->getApplication()->find('xf-dev:export');

--- a/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
+++ b/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
@@ -57,24 +57,16 @@ class BetterExport extends Command
         ]);
         $command->run($childInput, $output);
 
-        // xf 2.0.2 bug workaround
         $entityPath = $addOn->getAddOnDirectory() . DIRECTORY_SEPARATOR . 'Entity';
         $entityDirExists = is_dir($entityPath);
-        if (!$entityDirExists)
+        if ($entityDirExists)
         {
-            File::createDirectory($entityPath, false);
-        }
-
-        $command = $this->getApplication()->find('xf-dev:entity-class-properties');
-        $childInput = new ArrayInput([
-            'command' => 'xf-dev:entity-class-properties',
-            'addon-or-entity' => $addOn->getAddOnId()
-        ]);
-        $command->run($childInput, $output);
-
-        if (!$entityDirExists && is_dir($entityPath))
-        {
-            File::deleteDirectory($entityPath);
+            $command = $this->getApplication()->find('xf-dev:entity-class-properties');
+            $childInput = new ArrayInput([
+                'command' => 'xf-dev:entity-class-properties',
+                'addon-or-entity' => $addOn->getAddOnId()
+            ]);
+            $command->run($childInput, $output);
         }
 
         $command = $this->getApplication()->find('xf-dev:export');

--- a/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
+++ b/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/BetterExport.php
@@ -57,7 +57,6 @@ class BetterExport extends Command
         ]);
         $command->run($childInput, $output);
 
-        // xf 2.0.2 bug workaround
         $entityPath = $addOn->getAddOnDirectory() . DIRECTORY_SEPARATOR . 'Entity';
         $entityDirExists = is_dir($entityPath);
         if ($entityDirExists)


### PR DESCRIPTION
The xf-dev:entity-class-properties command should not be run when it is unneeded. The comment about a bug in XF 2.0.2+ is also factually incorrect.