### PR TITLE
"custom.subdir" support

### DIFF
--- a/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/Git/Commit.php
+++ b/upload/src/addons/TickTackk/DeveloperTools/Cli/Command/Git/Commit.php
@@ -52,7 +52,6 @@ class Commit extends Command
         $addOnDirectory = $addOn->getAddOnDirectory();
         $ds = DIRECTORY_SEPARATOR;
         $repoRoot = $addOnDirectory . $ds . '_repo';
-        $uploadDirectory = $repoRoot . $ds . 'upload';
 
         $git = new GitRepository($repoRoot);
         if (!$git->isInitialized())
@@ -79,7 +78,21 @@ class Commit extends Command
             $output->writeln(["", "Git username or email cannot be empty."]);
             return 1;
         }
-
+    
+        $globalGitIgnore = \XF::app()->options()->developerTools_git_ignore;
+    
+        if (!empty($globalGitIgnore))
+        {
+            File::writeFile($repoRoot . $ds . '.gitignore', $globalGitIgnore, false);
+        }
+    
+        $customSubDir = $git->config()->get('custom.subdir')->execute();
+        if (!empty($customSubDir))
+        {
+            $repoRoot .= ($ds . $customSubDir);
+        }
+        $uploadDirectory = $repoRoot . $ds . 'upload';
+    
         if (is_dir($repoRoot))
         {
             if (file_exists($uploadDirectory))
@@ -129,15 +142,9 @@ class Commit extends Command
             File::writeFile($repoRoot . $ds . 'LICENSE.md', $addOnEntity->license, false);
         }
 
-        $globalGitIgnore = \XF::app()->options()->developerTools_git_ignore;
-
         if (!empty($addOnEntity->gitignore))
         {
             File::writeFile($srcRoot . $ds . '.gitignore', $addOnEntity->gitignore, false);
-        }
-        else if (!empty($globalGitIgnore))
-        {
-            File::writeFile($repoRoot . $ds . '.gitignore', $globalGitIgnore, false);
         }
     
         if (!empty($addOnEntity->readme_md))


### PR DESCRIPTION
This is a new git config option that allows people to specify a subdirectory of their repository any particular add-on should insert itself into.

This is useful in case someone uses either one large repo for all their XF2 work (for some reason) or if, like me, they are using post-commit hooks that read the subdirectory name for deployment purposes.