### PR TITLE
Disable polyfill for JsMinifier closure

### DIFF
--- a/XF/Service/AddOn/JsMinifier.php
+++ b/XF/Service/AddOn/JsMinifier.php
@@ -32,7 +32,7 @@ class JsMinifier extends XFCP_JsMinifier
             throw new ClosureCompilerNotFoundException();
         }
 
-        \passthru("java -jar {$closureJarPath} --js {$jsPath} --js_output_file {$this->minPath}", $exitCode);
+        \passthru("java -jar {$closureJarPath} --rewrite_polyfills=false --warning_level=QUIET --js {$jsPath} --js_output_file {$this->minPath}", $exitCode);
         if ($exitCode !== 0)
         {
             throw new \ErrorException('Unable to minify ' . $jsPath);


### PR DESCRIPTION
By default, the Java application will add polyfill for some standard JS functions that are not needed, bloating the size of the minified JS file.

These additional flags will make the generated minified JS file mirror the web version used by XenForo.